### PR TITLE
Security patch 2

### DIFF
--- a/src/notes/notes.service.ts
+++ b/src/notes/notes.service.ts
@@ -12,7 +12,7 @@ export class NotesService {
 	}
 
 	async findOne(id: string): Promise<Note> {
-		return await this.noteModel.findOne({ _id: id });
+		return await this.noteModel.findOne({ _id: { $eq: id } });
 	}
 
 	async create(note: Note): Promise<Note> {
@@ -21,10 +21,11 @@ export class NotesService {
 	}
 
 	async delete(id: string): Promise<Note> {
-		return await this.noteModel.findByIdAndRemove(id);
+		return await this.noteModel.findByIdAndRemove({ $eq: id });
 	}
 
 	async update(id: string, note: Note) {
-		return await this.noteModel.findByIdAndUpdate(id, note, { new: false });
+		// TODO: sanitize the update note
+		return await this.noteModel.findByIdAndUpdate({ $eq: id }, note, { new: false });
 	}
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -12,7 +12,7 @@ export class UsersService {
 	}
 
 	async findOne(username: string): Promise<User> {
-		return await this.userModel.findOne({ username: username });
+		return await this.userModel.findOne({ username: { $eq: username } });
 	}
 
 	async create(user: User): Promise<User> {
@@ -21,12 +21,12 @@ export class UsersService {
 	}
 
 	async delete(username: string): Promise<User> {
-		return await this.userModel.findOneAndRemove({ username: username });
+		return await this.userModel.findOneAndRemove({ username: { $eq: username } });
 	}
 
 	async update(username: string, user: User) {
 		return await this.userModel.findOneAndUpdate(
-			{ username: username },
+			{ username: { $eq: username } },
 			user,
 			{ new: false },
 		);


### PR DESCRIPTION
---
name: security patch 2
about: add basic query casting
aim: bug-fix
commit: 57c2d3715cff4846363ace1d5788479199edb3f7
---

#### PR Change Description
Added basic query casting to notes and user module queries in their respective services.
`$eq` specifies equality condition. The `$eq` operator matches documents where the value of a field equals the specified value.
```json
{ <field>: { $eq: <value> } }
```
Specifying the `$eq` operator is equivalent to using the form `{ field: <value> }` except when the `<value>` is a regular expression.

Closes #27 

#### Files Changed
- [src/notes/notes.service.ts](https://github.com/khushalbhardwaj-0111/notary-API/blob/80542dd61f8ecc382890c40c2b43dcba065d3c56/src/users/users.service.ts)
- [src/notes/notes.service.ts](https://github.com/khushalbhardwaj-0111/notary-API/blob/80542dd61f8ecc382890c40c2b43dcba065d3c56/src/notes/notes.service.ts#L28-L28)

#### Commit(s)
- ac99ac4230581ac8df039f671948f04e41052f0c
- b46afc089b6a2b0f033058bbc22cd296ef552982

#### Additional Info
Check the MongoDB docs for reference on `$eq` operator [here](https://docs.mongodb.com/manual/reference/operator/query/eq/).